### PR TITLE
Changed the way raw data is copied to a buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bootloaders/*/build/
 **/*/*.project
 **/*/*.settings
 **/*/*.launch
+
+*.swp

--- a/libraries/FreeIMUUtils/CommunicationUtils.cpp
+++ b/libraries/FreeIMUUtils/CommunicationUtils.cpp
@@ -45,9 +45,7 @@ void toPrintableFloatArr(float* arr, int length, char* result) {
   char* buffer;
 
   for(int i=0; i<length; i++) {
-    toPrintableFloat(arr[i], result);
-    // Serial.print(",");
-    sprintf(result, "%s,", result);
+    toPrintableFloat(arr[i], &result[i*8]); // 8 bytes per hex float outpit
   }
 }
 
@@ -60,25 +58,24 @@ void toPrintableFloat(float f, char* result) {
     byte b1 = (b[i] >> 4) & 0x0f;
     byte b2 = (b[i] & 0x0f);
     
-    char c1 = (b1 < 10) ? ('0' + b1) : 'A' + b1 - 10;
-    char c2 = (b2 < 10) ? ('0' + b2) : 'A' + b2 - 10;
-    
-    sprintf(result, "%s%s%s", result, c1, c2);
+    *result++ = (b1 < 10) ? ('0' + b1) : 'A' + b1 - 10;
+    *result++ = (b2 < 10) ? ('0' + b2) : 'A' + b2 - 10;
   }
+  *result = '\0';
 }
 
 // Same as writeArr(), but appends to a 'result' char array instead of printing to serial output.
-void toPrintableArr(void* varr, uint8_t arr_length, uint8_t type_bytes, char* result) {
+// returns number of bytes written to array
+int toPrintableArr(void* varr, uint8_t arr_length, uint8_t type_bytes, char* result) {
   byte * arr = (byte*) varr;
+  result = &result[strlen(result)]; // append to end of result
   for(uint8_t i=0; i<arr_length; i++) {
-    toPrintableVar(&arr[i * type_bytes], type_bytes, result);
+    toPrintableVar(&arr[i * type_bytes], type_bytes, &result[i*type_bytes]);
   }
+  return arr_length * type_bytes;
 }
 
 // Same as writeVar(), but appends to a 'result' char array instead of printing to serial output.
 void toPrintableVar(void* val, uint8_t type_bytes, char* result) {
-  byte * addr=(byte *)(val);
-  for(uint8_t i=0; i<type_bytes; i++) { 
-    sprintf(result, "%s%s", result, addr[i]);
-  }
+    memcpy((void *)result, (void *)val, type_bytes);
 }

--- a/libraries/FreeIMUUtils/CommunicationUtils.h
+++ b/libraries/FreeIMUUtils/CommunicationUtils.h
@@ -15,6 +15,6 @@ void writeVar(void * val, uint8_t type_bytes);
 
 void toPrintableFloatArr(float * arr, int length, char* result);
 void toPrintableFloat(float f, char* result);
-void toPrintableArr(void* varr, uint8_t arr_length, uint8_t type_bytes, char* result);
+int  toPrintableArr(void* varr, uint8_t arr_length, uint8_t type_bytes, char* result);
 void toPrintableVar(void* val, uint8_t type_bytes, char* result);
 #endif // CommunitationUtils_h


### PR DESCRIPTION
toPrintableVar now uses memcpy instead of sprints to copy raw data to
result buffer. toPrintableArr now returns number of bytes placed in
buffer.