### PR TITLE
PLEASE DON'T MERGE BEFORE TESTING > Support serial number on USB

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -50,6 +50,7 @@ You must issue a `SET_CONFIG` command after you are done issuing networking libr
 
 | Command (comm)        | Where | Params       | Info                                                    |
 |:---------------------:| ----- |:------------:| ------------------------------------------------------- |
+| s                     | All  | none | Returns the device serial number |
 | SET_REPEAT:flw:comm   | All  | int flow, comm| Repeat send. flw 0x00 = off, 0x01 = on. Comm is optional|
 | SET_NODE_ID:node_id   | All   | int node_id  | Sets internal node ID to `node_id` (0x0001-0xfffe)      |
 | SET_DEST_ID:node_id   | All   | int node_id  | Sets internal dest ID to `node_id` (0x0001-0xfffe)      |
@@ -95,7 +96,7 @@ Set TX Power for internal at86rf233 RF module. Default is 0x0 (+4 dbm)
 
 ## Peripheral library commands - Real Time Clock (RTC)
 
-You will need to call `START_RTC` before using any of these commands. 
+You will need to call `START_RTC` before using any of these commands.
 
 | Command                                  | Where | Params                 | Info                  |
 |:----------------------------------------:| ----- |:----------------------:| --------------------- |

--- a/cores/arduino_osc32k/USB/USBCore.cpp
+++ b/cores/arduino_osc32k/USB/USBCore.cpp
@@ -222,9 +222,16 @@ bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 		else if (setup.wValueL == ISERIAL) {
 #ifdef PLUGGABLE_USB_ENABLED
 			char name[ISERIAL_MAX_LEN];
+  #ifdef __SAMR21E18A__
+			// dirty way
+			// Receiving xor'ed SAM R1 serial number, 8.8.3 in https://www.mouser.com/ds/2/268/Atmel-42223-SAM-R21_Datasheet-1065540.pdf
+			snprintf(name, ISERIAL_MAX_LEN, "%08x", (*(uint32_t *)(0x0080A00C)) ^ (*(uint32_t *)(0x0080A040)) ^ (*(uint32_t *)(0x0080A044)) ^ (*(uint32_t *)(0x0080A048)));
+  #else
 			PluggableUSB().getShortName(name);
+  #endif
 			return sendStringDescriptor((uint8_t*)name, setup.wLength);
 #endif
+
 		}
 		else {
 			return false;
@@ -942,4 +949,3 @@ void USBDeviceClass::ISRHandler()
 
 // USBDevice class instance
 USBDeviceClass USBDevice;
-

--- a/libraries/FemtoBeacon_Rf/FemtoCore_r2.0.7/FemtoCore_r2.0.7.ino
+++ b/libraries/FemtoBeacon_Rf/FemtoCore_r2.0.7/FemtoCore_r2.0.7.ino
@@ -65,4 +65,3 @@ void loop() {
   FemtoCore::handleNetworking(); // Required to call SYS_TaskHandler() of LwMesh stack library (handles networking stuff).
   FemtoCore::handleSerial();
 }
-

--- a/libraries/FemtoCore/FemtoCore.h
+++ b/libraries/FemtoCore/FemtoCore.h
@@ -30,7 +30,7 @@
 
 
     /** BEGIN mjs513 fork https://github.com/femtoduino/FreeIMU-Updates library. **/
-    
+
     //#include "calibration.h" // Uncomment once you have calibrated your IMU, generated a calibration.h file and updated FreeIMU.h!
 
     #include <I2Cdev.h>
@@ -86,7 +86,7 @@
 
     /** Networking vars EOF **/
 
-    
+
     /** RGB timer stuff BOF **/
     // Should be fast enough to fake PWM the Red pin.
     #define FEMTO_RGB_MAX_DUTY_CYCLE 48
@@ -100,12 +100,12 @@
     void tcDisable();
 
     /** RGB timer stuff EOF **/
-    
 
-    class FemtoCore 
+
+    class FemtoCore
     {
         public:
-            
+
             /**
              * Constructor.
              */
@@ -115,10 +115,10 @@
             // Sensor peripherals (9-DoF Sensor, Precision Altimeter)
             // ... FreeIMU Serial commands.
 
-            // @TODO USB peripherals 
+            // @TODO USB peripherals
 
             // @TODO OTA Updates
-            
+
             /**
              *           -----+ Common Anode (Pad #1 TOP VIEW)
              *    +---+ +---+ |
@@ -165,7 +165,7 @@
             static const int FEMTO_ANTENNA_UFL = 2;
 
             /** BEGIN Serial Rx **/
-            
+
             static volatile bool   stringComplete;  // whether the string is complete
             /** END Serial Rx **/
 
@@ -198,7 +198,7 @@
             static const byte FEMTO_SENSOR_INT_I2C_MASTER_INTERRUPT = 0x10; // DEC 16
             static const byte FEMTO_SENSOR_INT_DATA_READY           = 0x20; // DEC 32
             /** Sleep/Wake EOF **/
-            
+
 
             /**
              * @param int appAddress This node's address.
@@ -210,12 +210,12 @@
              * @param bool is_coin If true, we identify as a FemtoBeacon coin (with sensors). False means it's a dongle (no sensors).
              */
             static void init(
-                int appAddress, 
-                int destAddress, 
-                int appEndpoint, 
-                int appPanID, 
-                int appChannel, 
-                char* appSecurityKey, 
+                int appAddress,
+                int destAddress,
+                int appEndpoint,
+                int appPanID,
+                int appChannel,
+                char* appSecurityKey,
                 bool is_coin);
 
             static void startRTC();
@@ -341,7 +341,7 @@
 
             static volatile long _rgbLastTick;
             static volatile long _rgbCurrentTick;
-            
+
 
             static volatile long _rgbRedTick;
             static volatile long _rgbGreenTick;
@@ -410,11 +410,15 @@
             static char    _free_imu_serial_data[FREEIMU_OUTPUT_BUFFER_SIZE]; // Used by processCommand(). In the original FreeIMU_serial_ARM_CPU sketch, the "str" char array was hard-coded to 128 characters.
             static int     _free_imu_raw_values[11]; // Buffer to hold FreeIMU raw value data.
 
+
+	    static uint32_t _serialNumber; // Initialized at init, receiving serial SAM R21 number, 8.8.3 in https://www.mouser.com/ds/2/268/Atmel-42223-SAM-R21_Datasheet-1065540.pdf
+
+
             static NWK_DataReq_t _sendRequest;
 
             static void _HSV_to_RGB(float h, float s, float v, byte* r, byte* g, byte* b);
 
-            
+
             static void _configureAntenna();
             static void _setupRGB();
             static void _setupSerial();


### PR DESCRIPTION
Please test on Windows and Linux computer. Tested on OSX.

---

Adding serial number support ('Each device has a unique 128-bit serial number which is a concatenation of four 32-bit words')

Based on chapter 8.8.3 of https://www.mouser.com/ds/2/268/Atmel-42223-SAM-R21_Datasheet-1065540.pdf

Computing an XOR'ed 32-bit value of (*(uint32_t *)(0x0080A00C)) ^ (*(uint32_t *)(0x0080A040)) ^ (*(uint32_t *)(0x0080A044)) ^ (*(uint32_t *)(0x0080A048))

- Displaying this value when using the newly created 's' command
- Using this value as USB device serial number when __SAMR21E18A__ is define (-D__SAMR21E18A__)